### PR TITLE
Add continue-on-error to DigitalOcean deploy step

### DIFF
--- a/.github/workflows/manual_deploy.yml
+++ b/.github/workflows/manual_deploy.yml
@@ -24,6 +24,7 @@ jobs:
 
     - name: Deploy Main to DigitalOcean
       id: auto_deploy
+      continue-on-error: true
       run: |
         ssh -i ~/.ssh/deploy_key ${{ secrets.DROPLET_USER }}@${{ secrets.DROPLET_HOST }} '
           cd /home/django/dev3_cust2


### PR DESCRIPTION
Allow deployment to continue even if an error occurs.